### PR TITLE
Updated GET_STOCKS url to the newest link

### DIFF
--- a/degiroapi/__init__.py
+++ b/degiroapi/__init__.py
@@ -14,7 +14,7 @@ class DeGiro(object):
 
     __CLIENT_INFO_URL = 'https://trader.degiro.nl/pa/secure/client'
 
-    __GET_STOCKS_URL = 'https://trader.degiro.nl/products_s/secure/v5/stocks'
+    __GET_STOCKS_URL = 'https://trader.degiro.nl/product_search/secure/v5/stocks'
     __PRODUCT_SEARCH_URL = 'https://trader.degiro.nl/product_search/secure/v5/products/lookup'
     __PRODUCT_INFO_URL = 'https://trader.degiro.nl/product_search/secure/v5/products/info'
     __ID_DICTIONARY_URL = 'https://trader.degiro.nl/product_search/config/dictionary'


### PR DESCRIPTION
The __GET_STOCKS_URL stopped working during the weekend. This is the new url that should be used